### PR TITLE
test: add tests for LimitedStakeRewardReceiver

### DIFF
--- a/contracts/LimitedStakeRewardReceiver.sol
+++ b/contracts/LimitedStakeRewardReceiver.sol
@@ -12,9 +12,9 @@ import { ILimitedStakeRewardReceiver } from "./interfaces/ILimitedStakeRewardRec
 ///  more information that can be found here: https://www.halborn.com/blog/post/what-is-timestamp-dependence
 contract LimitedStakeRewardReceiver is ILimitedStakeRewardReceiver {
     /// @notice The hashed beneficiary address
-    bytes32 public constant BENEFICIARY = 0x85bb944aad1ac797ba6ab0cd69e14a9084d2edae32fdab7fbf5e21c3869bf862; // TODO: update to the actual value
+    bytes32 public constant BENEFICIARY = 0x8db6ec5b3d82a244eabfda6181bd25b3f6975b4dac11bdc43979fd7f4baed342; // TODO: update to the actual value
     /// @notice The treasury address
-    address public constant TREASURY = 0x812F55260F600bEC25A74811A7CB8D11Fe74299C; // TODO: update to the actual value
+    address public constant TREASURY = 0xb150dfd9539eDB8e0B19caA5ca37cf85Df487cC0; // TODO: update to the actual value
     /// @notice The unlock timestamp
     uint256 public constant UNLOCK_TIMESTAMP = 1767446400; // TODO: update to the actual value
     /// @notice The pre-unlock time maximum claimable rewards limit

--- a/contracts/LimitedStakeRewardReceiver.sol
+++ b/contracts/LimitedStakeRewardReceiver.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { ILimitedStakeRewardReceiver } from "./interfaces/ILimitedStakeRewardReceiver.sol";
+
+///  @title LimitedStakeRewardReceiver
+///  @notice Manages a custom time-locked unlocking logic for token rewards
+///  @dev Since block.timestamp is used, miner manipulation risk should be mentioned with
+///  more information that can be found here: https://www.halborn.com/blog/post/what-is-timestamp-dependence
+contract LimitedStakeRewardReceiver is ILimitedStakeRewardReceiver {
+    /// @notice The hashed beneficiary address
+    bytes32 public constant BENEFICIARY = 0x85bb944aad1ac797ba6ab0cd69e14a9084d2edae32fdab7fbf5e21c3869bf862; // TODO: update to the actual value
+    /// @notice The treasury address
+    address public constant TREASURY = 0x812F55260F600bEC25A74811A7CB8D11Fe74299C; // TODO: update to the actual value
+    /// @notice The unlock timestamp
+    uint256 public constant UNLOCK_TIMESTAMP = 1767446400; // TODO: update to the actual value
+    /// @notice The pre-unlock time maximum claimable rewards limit
+    uint256 public constant PRE_UNLOCK_MAX_REWARDS = 100; // TODO: update to the actual value
+    /// @notice The post-unlock time maximum claimable rewards limit
+    uint256 public constant POST_UNLOCK_MAX_REWARDS = 200; // TODO: update to the actual value
+
+    /// @notice The total claimed rewards so far
+    uint256 public totalClaimed;
+
+    // Custom errors
+    error NotBeneficiary();
+    error NoRewardsToClaim();
+    error NotEnoughRewardsToForward();
+
+    /// @notice Claims the beneficiary's rewards
+    function claimRewards() external {
+        if (_toHash(msg.sender) != BENEFICIARY) revert NotBeneficiary();
+
+        uint256 claimableAmount = _getClaimableAmount(); 
+        if (claimableAmount == 0) revert NoRewardsToClaim();
+
+        totalClaimed += claimableAmount;
+
+        Address.sendValue(payable(msg.sender), claimableAmount);
+
+        emit RewardsClaimed(claimableAmount);
+    }
+
+    /// @notice Forwards excess rewards to the treasury
+    function forwardExcessRewards() external {
+        // totalReceived = totalClaimed + address(this).balance + any amount previously forwarded.
+        // excessAmount at the function calling moment can ignore any amount previously forwarded amounts
+        // hence only using totalClaimed + address(this).balance
+        uint256 totalClaimedPlusBalance = totalClaimed + address(this).balance;
+        if (totalClaimedPlusBalance <= POST_UNLOCK_MAX_REWARDS) revert NotEnoughRewardsToForward();
+
+        uint256 excessAmount = totalClaimedPlusBalance - POST_UNLOCK_MAX_REWARDS;
+
+        Address.sendValue(payable(TREASURY), excessAmount);
+
+        emit ExcessRewardsForwarded(excessAmount);
+    }
+
+    /// @notice Returns the remaining total amount of rewards that can be claimed depending on the current timestamp
+    /// @return The remaining total amount of rewards that can be claimed
+    function getRemainingTotalAmount() external view returns (uint256) {
+        uint256 amountClaimed = totalClaimed;
+        if (block.timestamp <= UNLOCK_TIMESTAMP) {
+            // amountClaimed does not exceed PRE_UNLOCK_MAX_REWARDS before UNLOCK_TIMESTAMP due to _getClaimableAmount() logic
+            return PRE_UNLOCK_MAX_REWARDS - amountClaimed;
+        } else {
+            // amountClaimed does not exceed POST_UNLOCK_MAX_REWARDS after UNLOCK_TIMESTAMP due to _getClaimableAmount() logic
+            return POST_UNLOCK_MAX_REWARDS - amountClaimed;
+        }
+    }
+
+    /// @notice Returns the amount of rewards that can be claimed by the beneficiary
+    /// @return The amount of rewards that can be claimed by the beneficiary
+    function getClaimableAmount() external view returns (uint256) {
+        return _getClaimableAmount();
+    }
+
+    receive() external payable {}
+
+    /// @notice Returns the amount of rewards that can be claimed by the beneficiary
+    /// @return claimableAmount The amount of rewards that can be claimed by the beneficiary
+    function _getClaimableAmount() internal view returns (uint256 claimableAmount) {
+        uint256 amountClaimed = totalClaimed;
+        uint256 maxClaimableAmount;
+
+        if (block.timestamp <= UNLOCK_TIMESTAMP) {
+            if (amountClaimed > PRE_UNLOCK_MAX_REWARDS) return 0;
+            maxClaimableAmount = PRE_UNLOCK_MAX_REWARDS - amountClaimed;
+        } else {
+            if (amountClaimed > POST_UNLOCK_MAX_REWARDS) return 0;
+            maxClaimableAmount = POST_UNLOCK_MAX_REWARDS - amountClaimed;
+        }
+
+        claimableAmount = Math.min(maxClaimableAmount, address(this).balance);
+    }
+
+    /// @dev Returns the hashed beneficiary address
+    /// @param addr The address to hash
+    /// @return The hashed beneficiary address
+    function _toHash(address addr) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(addr));
+    }
+}

--- a/contracts/interfaces/ILimitedStakeRewardReceiver.sol
+++ b/contracts/interfaces/ILimitedStakeRewardReceiver.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title ILimitedStakeRewardReceiver
+/// @notice Interface for ILimitedStakeRewardReceiver. One beneficiary has one ILimitedStakeRewardReceiver.
+/// It is used to receive the staking rewards of the beneficiary
+interface ILimitedStakeRewardReceiver {
+    // @notice Emitted when the beneficiary claims their rewards
+    event RewardsClaimed(uint256 amount);
+    // @notice Emitted when excess rewards are forwarded to the treasury
+    event ExcessRewardsForwarded(uint256 amount);
+
+    // Functions
+    /// @notice Claims the beneficiary's rewards
+    function claimRewards() external;
+
+    /// @notice Forwards excess rewards to the treasury
+    function forwardExcessRewards() external;
+
+    /// @notice Returns the remaining total amount of rewards that can be claimed depending on the current timestamp
+    /// @return The remaining total amount of rewards that can be claimed
+    function getRemainingTotalAmount() external view returns (uint256);
+
+    /// @notice Returns the amount of rewards that can be claimed by the beneficiary
+    /// @return The amount of rewards that can be claimed by the beneficiary
+    function getClaimableAmount() external view returns (uint256);
+}

--- a/script/DeployLimitedStakeRewardReceiver.s.sol
+++ b/script/DeployLimitedStakeRewardReceiver.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {LimitedStakeRewardReceiver} from "../contracts/LimitedStakeRewardReceiver.sol";
+
+// forge script script/DeployLimitedStakeRewardReceiver.s.sol:DeployLimitedStakeRewardReceiver --rpc-url ${STORY_RPC} --broadcast --sender ${STORY_DEPLOYER_ADDRESS} --priority-gas-price 1 --legacy --verify --verifier=blockscout --verifier-url ${VERIFIER_URL} --private-key ${STORY_PRIVATEKEY}
+
+contract DeployLimitedStakeRewardReceiver is Script {
+
+    function run() public {
+        vm.startBroadcast();
+
+        address limitedStakeRewardReceiver = address(new LimitedStakeRewardReceiver());
+
+        console2.log("LimitedStakeRewardReceiver deployed at", limitedStakeRewardReceiver);
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/foundry/LimitedStakeRewardReceiver.t.sol
+++ b/test/foundry/LimitedStakeRewardReceiver.t.sol
@@ -21,7 +21,7 @@ contract LimitedStakeRewardReceiverTest is Test {
         limitedStakeRewardReceiver = new LimitedStakeRewardReceiver();
         stakingContract = IIPTokenStaking(address(0xCCcCcC0000000000000000000000000000000001));
 
-        beneficiary = 0x0aD06C3639E7Ef9F77c2b7057F5Ddf7A49949C6D;
+        beneficiary = 0xAa43aC49d67670477f998010e2DAEeDCb2c38fF7;
         bytes32 beneficiaryHash = keccak256(abi.encodePacked(beneficiary));
         // console2.logBytes32(beneficiaryHash);
         assertEq(limitedStakeRewardReceiver.BENEFICIARY(), beneficiaryHash);

--- a/test/foundry/LimitedStakeRewardReceiver.t.sol
+++ b/test/foundry/LimitedStakeRewardReceiver.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { LimitedStakeRewardReceiver } from "../../contracts/LimitedStakeRewardReceiver.sol";
+import { ILimitedStakeRewardReceiver } from "../../contracts/interfaces/ILimitedStakeRewardReceiver.sol";
+import { IIPTokenStaking } from "../../contracts/interfaces/IIPTokenStaking.sol";
+
+contract LimitedStakeRewardReceiverTest is Test {
+
+    LimitedStakeRewardReceiver public limitedStakeRewardReceiver;
+    IIPTokenStaking stakingContract;
+    address public beneficiary;
+
+    function setUp() public {
+        uint256 forkId = vm.createFork("https://aeneid.storyrpc.io");
+        vm.selectFork(forkId);
+
+        limitedStakeRewardReceiver = new LimitedStakeRewardReceiver();
+        stakingContract = IIPTokenStaking(address(0xCCcCcC0000000000000000000000000000000001));
+
+        beneficiary = 0x0aD06C3639E7Ef9F77c2b7057F5Ddf7A49949C6D;
+        bytes32 beneficiaryHash = keccak256(abi.encodePacked(beneficiary));
+        // console2.logBytes32(beneficiaryHash);
+        assertEq(limitedStakeRewardReceiver.BENEFICIARY(), beneficiaryHash);
+
+        vm.label(address(limitedStakeRewardReceiver), "limitedStakeRewardReceiver");
+        vm.label(address(stakingContract), "stakingContract");
+        vm.label(beneficiary, "beneficiary");
+        vm.label(limitedStakeRewardReceiver.TREASURY(), "treasury");
+    }
+
+    function test_claimRewards_revert_NotBeneficiary() public {
+        vm.prank(address(11));
+        vm.expectRevert(LimitedStakeRewardReceiver.NotBeneficiary.selector);
+        limitedStakeRewardReceiver.claimRewards();
+    }
+
+    function test_claimRewards_revert_NoRewardsToClaim_EmptyVault() public {
+        vm.prank(beneficiary);
+        vm.expectRevert(LimitedStakeRewardReceiver.NoRewardsToClaim.selector);
+        limitedStakeRewardReceiver.claimRewards();
+    }
+
+    function test_claimRewards_revert_NoRewardsToClaim_PreUnlockLimitReached() public {
+        // fund the contract to simulate earned staking rewards
+        vm.deal(address(limitedStakeRewardReceiver), limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS() + 1);
+
+        uint256 beneficiaryBalanceBefore = address(beneficiary).balance;
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter = address(beneficiary).balance;
+        assertEq(beneficiaryBalanceAfter - beneficiaryBalanceBefore, limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS());
+        assertEq(address(limitedStakeRewardReceiver).balance, 1);
+
+        vm.expectRevert(LimitedStakeRewardReceiver.NoRewardsToClaim.selector);
+        limitedStakeRewardReceiver.claimRewards();
+    }
+
+    function test_claimRewards_revert_NoRewardsToClaim_PostUnlockLimitReached() public {
+        vm.warp(block.timestamp + 1000 days);
+
+        // fund the contract to simulate earned staking rewards
+        vm.deal(address(limitedStakeRewardReceiver), limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS() + 1);
+
+        uint256 beneficiaryBalanceBefore = address(beneficiary).balance;
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter = address(beneficiary).balance;
+        assertEq(beneficiaryBalanceAfter - beneficiaryBalanceBefore, limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS());
+        assertEq(address(limitedStakeRewardReceiver).balance, 1);
+        
+        vm.expectRevert(LimitedStakeRewardReceiver.NoRewardsToClaim.selector);
+        limitedStakeRewardReceiver.claimRewards();
+    }
+
+    function test_claimRewards_PreUnlock() public {
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards1 = limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS() / 2;
+        vm.deal(address(limitedStakeRewardReceiver), rewards1);
+
+        assertEq(limitedStakeRewardReceiver.getClaimableAmount(), rewards1);
+
+        uint256 beneficiaryBalanceBefore = address(beneficiary).balance;
+        uint256 contractBalanceBefore = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedBefore = limitedStakeRewardReceiver.totalClaimed();
+
+        vm.expectEmit();
+        emit ILimitedStakeRewardReceiver.RewardsClaimed(rewards1);
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter = address(beneficiary).balance;
+        uint256 contractBalanceAfter = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedAfter = limitedStakeRewardReceiver.totalClaimed();
+
+        assertEq(beneficiaryBalanceAfter - beneficiaryBalanceBefore, rewards1);
+        assertEq(contractBalanceBefore - contractBalanceAfter, rewards1);
+        assertEq(totalClaimedAfter - totalClaimedBefore, rewards1);
+
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards2 = limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS() / 2;
+        vm.deal(address(limitedStakeRewardReceiver), rewards2);
+
+        uint256 beneficiaryBalanceBefore2 = address(beneficiary).balance;
+        uint256 contractBalanceBefore2 = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedBefore2 = limitedStakeRewardReceiver.totalClaimed();
+
+        vm.expectEmit();
+        emit ILimitedStakeRewardReceiver.RewardsClaimed(rewards2);
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter2 = address(beneficiary).balance;
+        uint256 contractBalanceAfter2 = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedAfter2 = limitedStakeRewardReceiver.totalClaimed();
+
+        assertEq(beneficiaryBalanceAfter2 - beneficiaryBalanceBefore2, rewards2);
+        assertEq(contractBalanceBefore2 - contractBalanceAfter2, rewards2);
+        assertEq(totalClaimedAfter2 - totalClaimedBefore2, rewards2);
+    }
+
+    function test_claimRewards_PostUnlock() public {
+        vm.warp(block.timestamp + 1000 days);
+
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards1 = limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS() / 2;
+        vm.deal(address(limitedStakeRewardReceiver), rewards1);
+
+        uint256 beneficiaryBalanceBefore = address(beneficiary).balance;
+        uint256 contractBalanceBefore = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedBefore = limitedStakeRewardReceiver.totalClaimed();
+
+        vm.expectEmit();
+        emit ILimitedStakeRewardReceiver.RewardsClaimed(rewards1);
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter = address(beneficiary).balance;
+        uint256 contractBalanceAfter = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedAfter = limitedStakeRewardReceiver.totalClaimed();
+
+        assertEq(beneficiaryBalanceAfter - beneficiaryBalanceBefore, rewards1);
+        assertEq(contractBalanceBefore - contractBalanceAfter, rewards1);
+        assertEq(totalClaimedAfter - totalClaimedBefore, rewards1);
+
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards2 = limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS() / 2;
+        vm.deal(address(limitedStakeRewardReceiver), rewards2);
+
+        uint256 beneficiaryBalanceBefore2 = address(beneficiary).balance;
+        uint256 contractBalanceBefore2 = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedBefore2 = limitedStakeRewardReceiver.totalClaimed();
+
+        vm.expectEmit();
+        emit ILimitedStakeRewardReceiver.RewardsClaimed(rewards2);
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        uint256 beneficiaryBalanceAfter2 = address(beneficiary).balance;
+        uint256 contractBalanceAfter2 = address(limitedStakeRewardReceiver).balance;
+        uint256 totalClaimedAfter2 = limitedStakeRewardReceiver.totalClaimed();
+
+        assertEq(beneficiaryBalanceAfter2 - beneficiaryBalanceBefore2, rewards2);
+        assertEq(contractBalanceBefore2 - contractBalanceAfter2, rewards2);
+        assertEq(totalClaimedAfter2 - totalClaimedBefore2, rewards2);
+    }
+
+    function test_forwardExcessRewards_revert_NotEnoughRewardsToForward() public {
+        vm.deal(address(limitedStakeRewardReceiver), limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS());
+
+        vm.expectRevert(LimitedStakeRewardReceiver.NotEnoughRewardsToForward.selector);
+        limitedStakeRewardReceiver.forwardExcessRewards();
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        vm.expectRevert(LimitedStakeRewardReceiver.NotEnoughRewardsToForward.selector);
+        limitedStakeRewardReceiver.forwardExcessRewards(); 
+
+        uint256 remainingBalance = limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS() - limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS();
+        assertEq(address(limitedStakeRewardReceiver).balance, remainingBalance);
+    }
+
+    function test_forwardExcessRewards() public {
+        vm.deal(address(limitedStakeRewardReceiver), limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS() + 1);
+
+        uint256 treasuryBalanceBefore = address(limitedStakeRewardReceiver.TREASURY()).balance;
+        uint256 contractBalanceBefore = address(limitedStakeRewardReceiver).balance;
+
+        vm.expectEmit();
+        emit ILimitedStakeRewardReceiver.ExcessRewardsForwarded(1);
+
+        limitedStakeRewardReceiver.forwardExcessRewards(); 
+
+        uint256 treasuryBalanceAfter = address(limitedStakeRewardReceiver.TREASURY()).balance;
+        uint256 contractBalanceAfter = address(limitedStakeRewardReceiver).balance;
+
+        assertEq(treasuryBalanceAfter - treasuryBalanceBefore, 1);
+        assertEq(contractBalanceBefore - contractBalanceAfter, 1);
+    }
+
+    function test_getRemainingTotalAmount_PreUnlock() public {
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards = limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS();
+        vm.deal(address(limitedStakeRewardReceiver), rewards);
+
+        uint256 remainingAmount = limitedStakeRewardReceiver.getRemainingTotalAmount();
+        assertEq(remainingAmount, limitedStakeRewardReceiver.PRE_UNLOCK_MAX_REWARDS());
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        remainingAmount = limitedStakeRewardReceiver.getRemainingTotalAmount();
+        assertEq(remainingAmount, 0);
+    }
+
+    function test_getRemainingTotalAmount_PostUnlock() public {
+        vm.warp(block.timestamp + 1000 days);
+
+        // fund the contract to simulate earned staking rewards
+        uint256 rewards = limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS();
+        vm.deal(address(limitedStakeRewardReceiver), rewards);
+
+        uint256 remainingAmount = limitedStakeRewardReceiver.getRemainingTotalAmount();
+        assertEq(remainingAmount, limitedStakeRewardReceiver.POST_UNLOCK_MAX_REWARDS());
+
+        vm.startPrank(beneficiary);
+        limitedStakeRewardReceiver.claimRewards();
+
+        remainingAmount = limitedStakeRewardReceiver.getRemainingTotalAmount();
+        assertEq(remainingAmount, 0);
+    }
+}
+


### PR DESCRIPTION
## Description

This PR adds comprehensive tests to cove boundary and edge cases for the `LimitedStakeRewardReceiver` contract.

- Test for handling large reward amounts and forwarding excess to the treasury
- Test for claimable amount at pre-unlock, unlock, and post-unlock boundaries
- Test for claimable amount at extreme timestamps (timestamp 0 and very large values)
- Test for claiming additional rewards after unlock if post-unlock max > pre-unlock max

### How to Test

Run:
```sh
forge test --match-path test/foundry/LimitedStakeRewardReceiver.t.sol
```
## Notes